### PR TITLE
chore: bump @fastly/cli to v14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@fastly/cli": "^13.0.0",
+    "@fastly/cli": "^14.0.0",
     "esbuild": "^0.25.0"
   },
   "scripts": {


### PR DESCRIPTION
Automated dependency bump across starter kits.